### PR TITLE
Remove bin from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _testmain.go
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+bin


### PR DESCRIPTION
`bin` should not be version controlled or it breaks goreleaser as git ends up in a dirty state after build