### PR TITLE
Fix goreleaser config

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,11 +1,11 @@
 builds:
-  - binary: ecs-exporter
-    goos:
-      - darwin
-      - linux
-      - windows
-    goarch:
-      - amd64
+  - skip: true
+    binary: bin/ecs-exporter
 archives:
   -
-    format: zip
+    format: binary
+    name_template: "ecs-exporter"
+release:
+  github:
+  extra_files:
+    - glob: ./bin/*


### PR DESCRIPTION
Skip build step and package the pre-built binary from the `make` run before deploy